### PR TITLE
HZN-1039 Update RestSharp to 106.12.0

### DIFF
--- a/sdk/Finbourne.Access.Sdk.Extensions.IntegrationTests/ApiExceptionExtensionsTest.cs
+++ b/sdk/Finbourne.Access.Sdk.Extensions.IntegrationTests/ApiExceptionExtensionsTest.cs
@@ -67,7 +67,7 @@ namespace Finbourne.Access.Sdk.Extensions.IntegrationTests
             {
                 //    ApiException.ErrorContent contains a JSON serialized ErrorResponse
                 LusidProblemDetails errorResponse = e.ProblemDetails();
-                Assert.That(errorResponse.Detail, Does.Match("One or more of the bits of input data provided were not valid.*"));
+                Assert.That(errorResponse.Detail, Is.EqualTo("One or more elements of the request were invalid. Please check that all supplied identifiers are valid and of the correct format, and that all provided data is correctly structured."));
             }
         }
 
@@ -102,16 +102,16 @@ namespace Finbourne.Access.Sdk.Extensions.IntegrationTests
                 //    An ApiException.ErrorContent thrown because of a request validation contains a JSON serialized LusidValidationProblemDetails
                 if (e.TryGetValidationProblemDetails(out var errorResponse))
                 {
-                    //Should identify that there was a validation error with the code
+                    //Should identify that there was a validation error with the code: Value must follow pattern ^(?=.*[a-zA-Z])[\w][\w +-]{2,100}$
                     Assert.That(errorResponse.Errors, Contains.Key("code"));
-                    Assert.That(errorResponse.Errors["code"].Single(), Is.EqualTo("Values for this field must be non-zero in length and be comprised of either alphanumeric characters, hyphens or underscores. For more information please consult the LUSID documentation."));
+                    Assert.That(errorResponse.Errors["code"].Single(), Is.EqualTo("Values for the field code must be comprised of either alphanumeric characters, hyphens or underscores. For more information please consult the documentation."));
 
-                    //Should identify that there was a validation error with the scope
+                    //Should identify that there was a validation error with the scope: Value must follow pattern ^(?=.*[a-zA-Z])[\w][\w +-]{2,100}$
                     Assert.That(errorResponse.Errors, Contains.Key("scope"));
-                    Assert.That(errorResponse.Errors["scope"].Single(), Is.EqualTo("Values for this field must be non-zero in length and be comprised of either alphanumeric characters, hyphens or underscores. For more information please consult the LUSID documentation."));
+                    Assert.That(errorResponse.Errors["scope"].Single(), Is.EqualTo("Values for the field scope must be comprised of either alphanumeric characters, hyphens or underscores. For more information please consult the documentation."));
 
-                    Assert.That(errorResponse.Detail, Does.Match("One or more of the bits of input data provided were not valid.*"));
-                    Assert.That(errorResponse.Name, Is.EqualTo("InvalidParameterValue"));
+                    Assert.That(errorResponse.Detail, Does.Match("One or more elements of the request were invalid.*"));
+                    Assert.That(errorResponse.Name, Is.EqualTo("InvalidRequestFailure"));
                 }
                 else
                 {
@@ -136,16 +136,16 @@ namespace Finbourne.Access.Sdk.Extensions.IntegrationTests
                 //    An ApiException.ErrorContent thrown because of a request validation contains a JSON serialized LusidValidationProblemDetails
                 if (e.TryGetValidationProblemDetails(out var errorResponse))
                 {
-                    //Should identify that there was a validation error with the code
+                    //Should identify that there was a validation error with the code: Value must follow pattern ^(?=.*[a-zA-Z])[\w][\w +-]{2,100}$
                     Assert.That(errorResponse.Errors, Contains.Key("code"));
-                    Assert.That(errorResponse.Errors["code"].Single(), Is.EqualTo("Supplied text value was too long to be valid"));
+                    Assert.That(errorResponse.Errors["code"].Single(), Is.EqualTo("Values for the field code must be comprised of either alphanumeric characters, hyphens or underscores. For more information please consult the documentation."));
 
-                    //Should identify that there was a validation error with the scope
+                    //Should identify that there was a validation error with the scope: Value must follow pattern ^(?=.*[a-zA-Z])[\w][\w +-]{2,100}$
                     Assert.That(errorResponse.Errors, Contains.Key("scope"));
-                    Assert.That(errorResponse.Errors["scope"].Single(), Is.EqualTo("Supplied text value was too long to be valid"));
+                    Assert.That(errorResponse.Errors["scope"].Single(), Is.EqualTo("Values for the field scope must be comprised of either alphanumeric characters, hyphens or underscores. For more information please consult the documentation."));
 
-                    Assert.That(errorResponse.Detail, Does.Match("One or more of the bits of input data provided were not valid.*"));
-                    Assert.That(errorResponse.Name, Is.EqualTo("InvalidParameterValue"));
+                    Assert.That(errorResponse.Detail, Does.Match("One or more elements of the request were invalid.*"));
+                    Assert.That(errorResponse.Name, Is.EqualTo("InvalidRequestFailure"));
                 }
                 else
                 {

--- a/sdk/Finbourne.Access.Sdk.Extensions.IntegrationTests/Finbourne.Access.Sdk.Extensions.IntegrationTests.csproj
+++ b/sdk/Finbourne.Access.Sdk.Extensions.IntegrationTests/Finbourne.Access.Sdk.Extensions.IntegrationTests.csproj
@@ -11,7 +11,7 @@
     <RepositoryType>git</RepositoryType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Finbourne.Access.Sdk.Preview" Version="0.0.3180" />
+    <PackageReference Include="Finbourne.Access.Sdk.Preview" Version="0.0.3228" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />

--- a/sdk/Finbourne.Access.Sdk.Extensions.IntegrationTests/Finbourne.Access.Sdk.Extensions.IntegrationTests.csproj
+++ b/sdk/Finbourne.Access.Sdk.Extensions.IntegrationTests/Finbourne.Access.Sdk.Extensions.IntegrationTests.csproj
@@ -11,7 +11,7 @@
     <RepositoryType>git</RepositoryType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Finbourne.Access.Sdk.Preview" Version="0.0.3228" />
+    <PackageReference Include="Finbourne.Access.Sdk.Preview" Version="0.0.3238" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />

--- a/sdk/Finbourne.Access.Sdk.Extensions.Tests/Finbourne.Access.Sdk.Extensions.Tests.csproj
+++ b/sdk/Finbourne.Access.Sdk.Extensions.Tests/Finbourne.Access.Sdk.Extensions.Tests.csproj
@@ -11,7 +11,7 @@
     <RepositoryType>git</RepositoryType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Finbourne.Access.Sdk.Preview" Version="0.0.3180" />
+    <PackageReference Include="Finbourne.Access.Sdk.Preview" Version="0.0.3228" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />

--- a/sdk/Finbourne.Access.Sdk.Extensions.Tests/Finbourne.Access.Sdk.Extensions.Tests.csproj
+++ b/sdk/Finbourne.Access.Sdk.Extensions.Tests/Finbourne.Access.Sdk.Extensions.Tests.csproj
@@ -11,7 +11,7 @@
     <RepositoryType>git</RepositoryType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Finbourne.Access.Sdk.Preview" Version="0.0.3228" />
+    <PackageReference Include="Finbourne.Access.Sdk.Preview" Version="0.0.3238" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />

--- a/sdk/Finbourne.Access.Sdk.Extensions/ApiResponseExtensions.cs
+++ b/sdk/Finbourne.Access.Sdk.Extensions/ApiResponseExtensions.cs
@@ -11,7 +11,7 @@ namespace Finbourne.Access.Sdk.Extensions
         /// <summary>
         /// The header that the request id is contained within.
         /// </summary>
-        public const string RequestIdHeader = "shrine-meta-requestId";
+        public const string RequestIdHeader = "shrine-meta-requestid";
         
         /// <summary>
         /// The header that the Date Time Offset is contained within.

--- a/sdk/Finbourne.Access.Sdk.Extensions/Finbourne.Access.Sdk.Extensions.csproj
+++ b/sdk/Finbourne.Access.Sdk.Extensions/Finbourne.Access.Sdk.Extensions.csproj
@@ -16,7 +16,7 @@
     <None Include="../../LICENSE.md" Pack="true" PackagePath="LICENSE.md" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Finbourne.Access.Sdk.Preview" Version="0.0.3228" />
+    <PackageReference Include="Finbourne.Access.Sdk.Preview" Version="0.0.3238" />
     <PackageReference Include="JsonSubTypes" Version="1.8.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />

--- a/sdk/Finbourne.Access.Sdk.Extensions/Finbourne.Access.Sdk.Extensions.csproj
+++ b/sdk/Finbourne.Access.Sdk.Extensions/Finbourne.Access.Sdk.Extensions.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Version>0.471.0</Version>
@@ -16,7 +16,7 @@
     <None Include="../../LICENSE.md" Pack="true" PackagePath="LICENSE.md" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Finbourne.Access.Sdk.Preview" Version="0.0.3180" />
+    <PackageReference Include="Finbourne.Access.Sdk.Preview" Version="0.0.3228" />
     <PackageReference Include="JsonSubTypes" Version="1.8.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
@@ -24,6 +24,6 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Polly" Version="7.2.1" />
-    <PackageReference Include="RestSharp" Version="106.11.7" />
+    <PackageReference Include="RestSharp" Version="106.12.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
# Pull Request Checklist

- [X] Read the [contributing guidelines](../blob/master/docs/CONTRIBUTING.md)
- [x] Tests pass
- [~] Raised the PR against the `develop` branch

# Description of the PR

Finbourne.Access.Sdk.Preview now references RestSharp 106.12.0 rather than 106.11.7 therefore the Finbourne.Access.Sdk.Extensions must reference the same version in order for the code to compile. Amended some test expectations based on changes to API validation logic.
