### PR TITLE
IAM-2433: Remove GetRole asAt usage from tests

### DIFF
--- a/sdk/Finbourne.Access.Sdk.Extensions.IntegrationTests/PollyApiRetryHandlerTest.cs
+++ b/sdk/Finbourne.Access.Sdk.Extensions.IntegrationTests/PollyApiRetryHandlerTest.cs
@@ -87,7 +87,7 @@ namespace Finbourne.Access.Sdk.Extensions.IntegrationTests
 
             RetryConfiguration.RetryPolicy = PollyApiRetryHandler.DefaultRetryPolicyWithFallback;
 
-            var sdkResponse = _apiFactory.Api<IRolesApi>().GetRole("code", DateTimeOffset.UtcNow.AddDays(-1), "scope");
+            var sdkResponse = _apiFactory.Api<IRolesApi>().GetRole("code", "scope");
 
             // Api call should be just called once
             Assert.That(_apiCallCount, Is.EqualTo(expectedNumberOfApiCalls));


### PR DESCRIPTION
# Pull Request Checklist

- [x] Read the [contributing guidelines](../blob/master/docs/CONTRIBUTING.md)
- [x] Tests pass

# Description of the PR

The `asAt` parameter on the `GetRole` endpoint is not implemented and has now been removed. This MR removes its usage from the integration tests